### PR TITLE
chore(ci): add release candidate branching

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,15 @@ updates:
     commit-message:
       # Prefix all commit messages with "chore: "
       prefix: "chore"
+    groups:
+      ai-dial-ci:
+        applies-to: version-updates
+        patterns:
+          - "epam/ai-dial-ci/*"
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "epam/ai-dial-ci/*"
+    open-pull-requests-limit: 10

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -1,9 +1,9 @@
 name: Deploy development
 
 on:
-  workflow_dispatch: 
-  registry_package: 
-  workflow_run:
+  workflow_dispatch: # manual run
+  registry_package: # on new package version (main path)
+  workflow_run: # HACK: redundant trigger to mitigate GitHub's huge delays in registry_package event processing
     workflows: ["Release Workflow"]
     types:
       - completed
@@ -14,7 +14,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.registry_package.package_version.container_metadata.tag.name == 'development' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'development')
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@2.6.0
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.0.0
     with:
       gitlab-project-id: "1831"
     secrets:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,12 +7,14 @@ on:
       - edited
       - reopened
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@2.6.0
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.0.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,5 +10,5 @@ concurrency:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/java_pr.yml@2.6.0
+    uses: epam/ai-dial-ci/.github/workflows/java_pr.yml@4.0.0
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release Workflow
 on:
   push:
     branches: [development, release-*]
+  workflow_dispatch:
+    inputs:
+      promote:
+        type: boolean
+        default: false
+        description: Promote release to stable (for release-* branches only)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,5 +16,7 @@ concurrency:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/java_release.yml@2.6.0
+    uses: epam/ai-dial-ci/.github/workflows/java_release.yml@4.0.0
+    with:
+      promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
     secrets: inherit

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Slash Command Dispatch
         id: scd
-        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4.0.0
+        uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2
         with:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           reaction-token: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = 17
 targetCompatibility = 17
 
 group = 'com.epam.aidial'
-version = "0.5.0-rc"
+version = "0.0.0"
 
 java {
     toolchain {

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,13 +1,14 @@
 # Trivy configuration file
 # https://aquasecurity.github.io/trivy/latest/docs/references/configuration/config-file/
-# Can be deleted after public ecr mirror will be added by default
 db:
   no-progress: true
   repository:
-    - ghcr.io/aquasecurity/trivy-db:2
+    - mirror.gcr.io/aquasec/trivy-db:2
     - public.ecr.aws/aquasecurity/trivy-db:2
+    - ghcr.io/aquasecurity/trivy-db:2
   java-repository:
-    - ghcr.io/aquasecurity/trivy-java-db:1
+    - mirror.gcr.io/aquasec/trivy-java-db:1
     - public.ecr.aws/aquasecurity/trivy-java-db:1
+    - ghcr.io/aquasecurity/trivy-java-db:1
 misconfiguration:
-  checks-bundle-repository: public.ecr.aws/aquasecurity/trivy-checks
+  checks-bundle-repository: mirror.gcr.io/aquasec/trivy-checks:1


### PR DESCRIPTION
- bump epam/ai-dial-ci workflow version and add promote input = enable release candidates for the given repo
- drop version in build.gradle file to dev marker (`0.0.0`)
- align additional Trivy configuration with reference
- minor workflow-related fixes & alignments